### PR TITLE
GROMOS class __init__ and _prepare

### DIFF
--- a/trajclustering/clustering.py
+++ b/trajclustering/clustering.py
@@ -3,10 +3,13 @@ from MDAnalysis.analysis.base import AnalysisBase
 import numpy as np
 
 class GROMOS(AnalysisBase):
-    def __init__(self, atomgroup, **kwargs):
+    def __init__(self, atomgroup, reference, **kwargs):
+        # sets up the self.atomgroup and self.reference variables
         self.atomgroup = atomgroup
+        self.reference = reference
         super().__init__(atomgroup.universe.trajectory,
                          **kwargs)
+
     def _prepare(self):
         # called before iteration on the trajectory has begun.
         # initialize results
@@ -14,7 +17,8 @@ class GROMOS(AnalysisBase):
         # here, probably make an array that assigns frames to a 
         # cluster 
         # OR probably 
-        pass
+        matrix = np.zeros((self.atomgroup.universe.trajectory.n_frames, 
+                           self.atomgroup.universe.trajectory.n_frames))
 
     def _single_frame(self):
         # called after the trajectory is moved onto each new frame.

--- a/trajclustering/clustering.py
+++ b/trajclustering/clustering.py
@@ -17,7 +17,7 @@ class GROMOS(AnalysisBase):
         # here, probably make an array that assigns frames to a 
         # cluster 
         # OR probably 
-        matrix = np.zeros((self.atomgroup.universe.trajectory.n_frames, 
+        self.matrix = np.zeros((self.atomgroup.universe.trajectory.n_frames, 
                            self.atomgroup.universe.trajectory.n_frames))
 
     def _single_frame(self):

--- a/trajclustering/tests/test_clustering.py
+++ b/trajclustering/tests/test_clustering.py
@@ -1,0 +1,26 @@
+from trajclustering import clustering
+import MDAnalysis as mda
+from MDAnalysisTests import datafiles as data
+
+import pytest
+
+@pytest.fixture
+def u():
+    return mda.Universe(data.GRO, data.XTC)
+
+def test_gromos_init(u):
+    u.select_atoms("backbone")
+    ref = u.select_atoms("backbone")
+
+    gromos = clustering.GROMOS(u.atoms, ref)
+    assert gromos.atomgroup == u.atoms
+    assert gromos.reference == ref
+
+def test_gromos_prepare(u):
+    u.select_atoms("backbone")
+    ref = u.select_atoms("backbone")
+
+    gromos = clustering.GROMOS(u.atoms, ref)
+    gromos._prepare()
+    assert gromos.matrix.shape == (u.trajectory.n_frames, u.trajectory.n_frames)
+    assert gromos.matrix.sum() == 0


### PR DESCRIPTION
Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - clustering.py
   - GROMOS.__init__(): the GROMOS class takes two atom groups and will create self variables for these two atom groups and initialize the AnalysisBase class.
   - GROMOS._prepare(): the GROMOS class will prepare by initializing a 2d matrix based on the number of frames in the trajectory
 - tests/test_clustering.py
   - Quick tests for both GROMOS.__init__() and GROMOS._preapre() to ensure proper generation of the self variables
